### PR TITLE
5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reciple",
-  "version": "5.0.0-pre.3",
+  "version": "5.0.0-pre.4",
   "bin": "bin/bin.js",
   "license": "GPL-3.0",
   "main": "bin/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reciple",
-  "version": "5.0.0-pre.1",
+  "version": "5.0.0-pre.2",
   "bin": "bin/bin.js",
   "license": "GPL-3.0",
   "main": "bin/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reciple",
-  "version": "5.0.0-pre.5",
+  "version": "5.0.0-pre.6",
   "bin": "bin/bin.js",
   "license": "GPL-3.0",
   "main": "bin/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reciple",
-  "version": "4.1.2",
+  "version": "5.0.0-pre.1",
   "bin": "bin/bin.js",
   "license": "GPL-3.0",
   "main": "bin/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reciple",
-  "version": "5.0.0-pre.7",
+  "version": "5.0.0",
   "bin": "bin/bin.js",
   "license": "GPL-3.0",
   "main": "bin/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reciple",
-  "version": "5.0.0-pre.6",
+  "version": "5.0.0-pre.7",
   "bin": "bin/bin.js",
   "license": "GPL-3.0",
   "main": "bin/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reciple",
-  "version": "5.0.0-pre.2",
+  "version": "5.0.0-pre.3",
   "bin": "bin/bin.js",
   "license": "GPL-3.0",
   "main": "bin/index.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "bin": "bin/bin.js",
   "license": "GPL-3.0",
   "main": "bin/index.js",
+  "typings": "bin/index.d.ts",
   "author": "FalloutStudios",
   "description": "Handler for Discord.js",
   "homepage": "https://reciple.js.org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reciple",
-  "version": "5.0.0-pre.4",
+  "version": "5.0.0-pre.5",
   "bin": "bin/bin.js",
   "license": "GPL-3.0",
   "main": "bin/index.js",

--- a/resource/reciple.yml
+++ b/resource/reciple.yml
@@ -49,16 +49,6 @@ commands:
           permissions: ['Administrator']
 
 
-# Ignored channel IDs
-ignoredChannels:
-  # enable ignored channels
-  enabled: false
-  # convert to only allowed channels
-  convertToAllowList: false
-  # channel IDs
-  channels: []
-
-
 # Logger options
 fileLogging:
   # enable console output to file

--- a/resource/reciple.yml
+++ b/resource/reciple.yml
@@ -60,7 +60,7 @@ fileLogging:
   # stringify logged JSONs
   stringifyLoggedJSON: false
   # log file path
-  logFilePath: './logs/latest.log'
+  logFilePath:
 
 # Client options
 # Learn more about client options at https://discord.js.org/#/docs/discord.js/main/typedef/ClientOptions

--- a/resource/reciple.yml
+++ b/resource/reciple.yml
@@ -23,8 +23,9 @@ commands:
       # enable overwriten command permissions
       enabled: false
       commands:
-        - command: 'example-command'
-          permissions: ['Administrator']
+        - command: example-command
+          permissions:
+            - Administrator
 
   # Interaction command options
   slashCommand:
@@ -45,8 +46,9 @@ commands:
       # enable overwriten command permissions
       enabled: false
       commands:
-        - command: 'example-command'
-          permissions: ['Administrator']
+        - command: example-command
+          permissions:
+            - Administrator
 
 
 # Logger options
@@ -60,32 +62,32 @@ fileLogging:
   # stringify logged JSONs
   stringifyLoggedJSON: false
   # log file path
-  logFilePath:
+  logFilePath: logs/latest.log
 
 # Client options
 # Learn more about client options at https://discord.js.org/#/docs/discord.js/main/typedef/ClientOptions
 client:
   intents:
-    - 'Guilds'
-    - 'GuildMembers'
-    - 'GuildMessages'
-    - 'MessageContent'
+    - Guilds
+    - GuildMembers
+    - GuildMessages
+    - MessageContent
 
 # Bot messages
 messages:
-  missingArguments: 'Not enough arguments.'
-  invalidArguments: 'Invalid argument(s) given.'
+  missingArguments: Not enough arguments.
+  invalidArguments: Invalid argument(s) given.
   insufficientBotPerms:
-    content: 'Insufficient bot permissions.'
+    content: Insufficient bot permissions.
     ephemeral: true
   noPermissions:
-    content: 'You do not have permission to use this command.'
+    content: You do not have permission to use this command.
     ephemeral: true
   cooldown:
-    content: 'You cannot execute this command right now due to the cooldown.'
+    content: You cannot execute this command right now due to the cooldown.
     ephemeral: true
   error:
-    content: 'An error occurred.'
+    content: An error occurred.
     ephemeral: true
 
 # Ignored Files

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -36,6 +36,10 @@ if (config.fileLogging.clientLogs) client.logger.info('Reciple Client v' + rawVe
     client.on('ready', async () => {
         if (client.isClientLogsEnabled()) client.logger.warn(`Logged in as ${client.user?.tag || 'Unknown'}!`);
 
+        client.on('cacheSweep', (message) => {
+            client.cooldowns.clean();
+        });
+
         await client.loadModules();
         client.addCommandListeners();
     });

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -36,7 +36,7 @@ if (config.fileLogging.clientLogs) client.logger.info('Reciple Client v' + rawVe
     client.on('ready', async () => {
         if (client.isClientLogsEnabled()) client.logger.warn(`Logged in as ${client.user?.tag || 'Unknown'}!`);
 
-        client.on('cacheSweep', (message) => {
+        client.on('cacheSweep', () => {
             client.cooldowns.clean();
         });
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -31,7 +31,7 @@ try {
 const config = configParser.getConfig();
 const client = new RecipleClient({ config: config, ...config.client });
 
-if (config.fileLogging.clientLogs) client.logger.info('Reciple Client v' + rawVersion + ' is starting...');
+if (config.fileLogging.clientLogs) client.logger.info('Starting Reciple client v' + rawVersion);
 
 (async () => {
     await client.startModules(normalizeArray(config.modulesFolder as RestOrArray<string>));

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,14 +4,17 @@ import { RecipleClient } from './reciple/classes/RecipleClient';
 import { RecipleConfig } from './reciple/classes/RecipleConfig';
 import { rawVersion } from './reciple/version';
 import { existsSync, readdirSync } from 'fs';
-import { flags } from './reciple/flags';
+import { cwd, flags } from './reciple/flags';
 import { input } from 'fallout-utility';
 import chalk from 'chalk';
 import 'dotenv/config';
+import { normalizeArray, RestOrArray } from 'discord.js';
+import path from 'path';
 
 const allowedFiles = ['node_modules', 'reciple.yml', 'package.json'];
+const configPath = path.join(cwd, './reciple.yml');
 
-if (readdirSync('./').filter(f => !f.startsWith('.') && allowedFiles.indexOf(f)).length > 0 && !existsSync(flags.config ?? './reciple.yml')) {
+if (readdirSync(cwd).filter(f => !f.startsWith('.') && allowedFiles.indexOf(f)).length > 0 && !existsSync(flags.config ?? configPath)) {
     const ask = (flags.yes ? 'y' : null) ?? input('This directory does not contain reciple.yml. Would you like to init axis here? [y/n] ') ?? '';
     if (ask.toString().toLowerCase() !== 'y') process.exit(0);
 }
@@ -19,7 +22,7 @@ if (readdirSync('./').filter(f => !f.startsWith('.') && allowedFiles.indexOf(f))
 let configParser: RecipleConfig;
 
 try {
-    configParser = new RecipleConfig(flags.config ?? './reciple.yml').parseConfig();
+    configParser = new RecipleConfig(flags.config ?? configPath).parseConfig();
 } catch (err) {
     console.error(`${chalk.bold.red('Config Error')}: ${chalk.white((err as Error).message)}`);
     process.exit(1);
@@ -31,7 +34,7 @@ const client = new RecipleClient({ config: config, ...config.client });
 if (config.fileLogging.clientLogs) client.logger.info('Reciple Client v' + rawVersion + ' is starting...');
 
 (async () => {
-    await client.startModules();
+    await client.startModules(normalizeArray(config.modulesFolder as RestOrArray<string>));
 
     client.on('ready', async () => {
         if (client.isClientLogsEnabled()) client.logger.warn(`Logged in as ${client.user?.tag || 'Unknown'}!`);

--- a/src/reciple/classes/CommandCooldownManager.ts
+++ b/src/reciple/classes/CommandCooldownManager.ts
@@ -1,4 +1,4 @@
-import { Guild, TextBasedChannel, User } from 'discord.js';
+import { Guild, normalizeArray, RestOrArray, TextBasedChannel, User } from 'discord.js';
 import { CommandBuilderType } from '../types/builders';
 
 /**
@@ -17,6 +17,10 @@ export interface CooledDownUser {
  * Stores cooled-down users
  */
 export class CommandCooldownManager extends Array<CooledDownUser> {
+    constructor(...data: RestOrArray<CooledDownUser>) {
+        super(...normalizeArray(data));
+    }
+
     /**
      * Alias for `CommandCooldownManager#push()`
      * @param options Cooled-down user data

--- a/src/reciple/classes/CommandCooldownManager.ts
+++ b/src/reciple/classes/CommandCooldownManager.ts
@@ -2,7 +2,7 @@ import { Guild, normalizeArray, RestOrArray, TextBasedChannel, User } from 'disc
 import { CommandBuilderType } from '../types/builders';
 
 /**
- * Object interface for cooled-down user
+ * cooled-down user object interface
  */
 export interface CooledDownUser {
     user: User;
@@ -14,7 +14,7 @@ export interface CooledDownUser {
 }
 
 /**
- * Stores cooled-down users
+ * cooled-down users manager
  */
 export class CommandCooldownManager extends Array<CooledDownUser> {
     constructor(...data: RestOrArray<CooledDownUser>) {

--- a/src/reciple/classes/MessageCommandOptionManager.ts
+++ b/src/reciple/classes/MessageCommandOptionManager.ts
@@ -5,9 +5,6 @@ import { normalizeArray, RestOrArray } from 'discord.js';
  * Validated message options manager
  */
 export class MessageCommandOptionManager extends Array<MessageCommandValidatedOption> {
-    /**
-     * @param data Validated options
-     */
     constructor(...data: RestOrArray<MessageCommandValidatedOption>) {
         super(...normalizeArray(data));
     }

--- a/src/reciple/classes/MessageCommandOptionManager.ts
+++ b/src/reciple/classes/MessageCommandOptionManager.ts
@@ -1,14 +1,15 @@
 import { MessageCommandValidatedOption } from './builders/MessageCommandBuilder';
+import { normalizeArray, RestOrArray } from 'discord.js';
 
 /**
  * Validated message options manager
  */
 export class MessageCommandOptionManager extends Array<MessageCommandValidatedOption> {
     /**
-     * @param options Validated options
+     * @param data Validated options
      */
-    constructor(...options: MessageCommandValidatedOption[]) {
-        super(...(options ?? []));
+    constructor(...data: RestOrArray<MessageCommandValidatedOption>) {
+        super(...normalizeArray(data));
     }
 
     /**

--- a/src/reciple/classes/RecipleClient.ts
+++ b/src/reciple/classes/RecipleClient.ts
@@ -93,7 +93,7 @@ export class RecipleClient<Ready extends boolean = boolean> extends Client<Ready
         if (!options.config) throw new Error('Config is not defined.');
         this.config = {...this.config, ...(options.config ?? {})};
 
-        if (this.config.fileLogging.enabled) this.logger.logFile(this.config.fileLogging.logFilePath ?? path.join(cwd, 'logs/latest.log'), false);
+        if (this.config.fileLogging.enabled) this.logger.logFile(path.join(cwd, this.config.fileLogging.logFilePath ?? 'logs/latest.log'), false);
     }
 
     /**

--- a/src/reciple/classes/RecipleClient.ts
+++ b/src/reciple/classes/RecipleClient.ts
@@ -1,8 +1,8 @@
 import { MessageCommandBuilder, MessageCommandExecuteData, MessageCommandHaltData, validateMessageCommandOptions } from './builders/MessageCommandBuilder';
 import { SlashCommandBuilder, SlashCommandExecuteData, SlashCommandHaltData } from './builders/SlashCommandBuilder';
 import { ApplicationCommandBuilder, registerApplicationCommands } from '../registerApplicationCommands';
-import { botHasExecutePermissions, isIgnoredChannel, userHasCommandPermissions } from '../permissions';
 import { AnyCommandBuilder, CommandBuilderType, AnyCommandExecuteData } from '../types/builders';
+import { botHasExecutePermissions, userHasCommandPermissions } from '../permissions';
 import { CommandCooldownManager, CooledDownUser } from './CommandCooldownManager';
 import { MessageCommandOptionManager } from './MessageCommandOptionManager';
 import { AnyCommandHaltData, CommandHaltReason } from '../types/commands';
@@ -234,13 +234,7 @@ export class RecipleClient<Ready extends boolean = boolean> extends Client<Ready
             memberPermissions: message.member?.permissions,
             commandPermissions: this.config.commands.messageCommand.permissions
         })) {
-            if (
-                !command.allowExecuteInDM && message.channel.type === ChannelType.DM
-                || !command.allowExecuteByBots
-                && (message.author.bot ||message.author.system)
-                || isIgnoredChannel(message.channelId, this.config.ignoredChannels)
-            ) return;
-
+            if (!command.allowExecuteInDM && message.channel.type === ChannelType.DM || !command.allowExecuteByBots && (message.author.bot ||message.author.system)) return;
             if (command.validateOptions) {
                 if (commandOptions.some(o => o.invalid)) {
                     if (!await this._haltCommand(command, { executeData, reason: CommandHaltReason.InvalidArguments, invalidArguments: new MessageCommandOptionManager(...executeData.options.filter(o => o.invalid)) })) {
@@ -319,8 +313,7 @@ export class RecipleClient<Ready extends boolean = boolean> extends Client<Ready
             memberPermissions: interaction.memberPermissions ?? undefined,
             commandPermissions: this.config.commands.slashCommand.permissions
         })) {
-            if (!command || isIgnoredChannel(interaction.channelId, this.config.ignoredChannels)) return;
-
+            if (!command) return;
             if (interaction.guild && !botHasExecutePermissions(interaction.guild, command.requiredBotPermissions)) {
                 if (!await this._haltCommand(command, { executeData, reason: CommandHaltReason.MissingBotPermissions })) {
                     await interaction.reply(this.getMessage('insufficientBotPerms', 'Insufficient bot permissions.')).catch(er => this._replyError(er));

--- a/src/reciple/classes/RecipleClient.ts
+++ b/src/reciple/classes/RecipleClient.ts
@@ -1,11 +1,11 @@
 import { MessageCommandBuilder, MessageCommandExecuteData, MessageCommandHaltData, validateMessageCommandOptions } from './builders/MessageCommandBuilder';
 import { SlashCommandBuilder, SlashCommandExecuteData, SlashCommandHaltData } from './builders/SlashCommandBuilder';
 import { ApplicationCommandBuilder, registerApplicationCommands } from '../registerApplicationCommands';
-import { AnyCommandBuilder, CommandBuilderType, AnyCommandExecuteData } from '../types/builders';
+import { AnyCommandExecuteData, AnyCommandHaltData, CommandHaltReason } from '../types/commands';
 import { botHasExecutePermissions, userHasCommandPermissions } from '../permissions';
 import { CommandCooldownManager, CooledDownUser } from './CommandCooldownManager';
 import { MessageCommandOptionManager } from './MessageCommandOptionManager';
-import { AnyCommandHaltData, CommandHaltReason } from '../types/commands';
+import { AnyCommandBuilder, CommandBuilderType } from '../types/builders';
 import { RecipleClientAddModuleOptions } from '../types/paramOptions';
 import { getCommand, Logger as ILogger } from 'fallout-utility';
 import { Config, RecipleConfig } from './RecipleConfig';

--- a/src/reciple/classes/RecipleClient.ts
+++ b/src/reciple/classes/RecipleClient.ts
@@ -73,7 +73,7 @@ export class RecipleClient<Ready extends boolean = boolean> extends Client<Ready
     public config: Config = RecipleConfig.getDefaultConfig();
     public commands: RecipleClientCommands = { messageCommands: {}, slashCommands: {} };
     public otherApplicationCommandData: (ApplicationCommandBuilder|ApplicationCommandData)[] = [];
-    public commandCooldowns: CommandCooldownManager = new CommandCooldownManager();
+    public cooldowns: CommandCooldownManager = new CommandCooldownManager();
     public modules: RecipleModule[] = [];
     public logger: ILogger;
     public version: string = version;
@@ -266,10 +266,10 @@ export class RecipleClient<Ready extends boolean = boolean> extends Client<Ready
                 type: CommandBuilderType.MessageCommand
             };
 
-            if (this.config.commands.messageCommand.enableCooldown && command.cooldown && !this.commandCooldowns.isCooledDown(userCooldown)) {
-                this.commandCooldowns.add({ ...userCooldown, expireTime: Date.now() + command.cooldown });
+            if (this.config.commands.messageCommand.enableCooldown && command.cooldown && !this.cooldowns.isCooledDown(userCooldown)) {
+                this.cooldowns.add({ ...userCooldown, expireTime: Date.now() + command.cooldown });
             } else if (this.config.commands.messageCommand.enableCooldown && command.cooldown) {
-                if (!await this._haltCommand(command, { executeData, reason: CommandHaltReason.Cooldown, ...this.commandCooldowns.get(userCooldown)! })) {
+                if (!await this._haltCommand(command, { executeData, reason: CommandHaltReason.Cooldown, ...this.cooldowns.get(userCooldown)! })) {
                     await message.reply(this.getMessage('cooldown', 'You cannot execute this command right now due to the cooldown.')).catch(er => this._replyError(er));
                 }
 
@@ -330,10 +330,10 @@ export class RecipleClient<Ready extends boolean = boolean> extends Client<Ready
                 type: CommandBuilderType.SlashCommand
             };
 
-            if (this.config.commands.slashCommand.enableCooldown && command.cooldown && !this.commandCooldowns.isCooledDown(userCooldown)) {
-                this.commandCooldowns.add({ ...userCooldown, expireTime: Date.now() + command.cooldown });
+            if (this.config.commands.slashCommand.enableCooldown && command.cooldown && !this.cooldowns.isCooledDown(userCooldown)) {
+                this.cooldowns.add({ ...userCooldown, expireTime: Date.now() + command.cooldown });
             } else if (this.config.commands.slashCommand.enableCooldown && command.cooldown) {
-                if (!await this._haltCommand(command, { executeData, reason: CommandHaltReason.Cooldown, ...this.commandCooldowns.get(userCooldown)! })) {
+                if (!await this._haltCommand(command, { executeData, reason: CommandHaltReason.Cooldown, ...this.cooldowns.get(userCooldown)! })) {
                     await interaction.reply(this.getMessage('cooldown', 'You cannot execute this command right now due to the cooldown.')).catch(er => this._replyError(er));
                 }
 

--- a/src/reciple/classes/RecipleClient.ts
+++ b/src/reciple/classes/RecipleClient.ts
@@ -26,6 +26,8 @@ import {
     normalizeArray,
     RestOrArray
 } from 'discord.js';
+import path from 'path';
+import { cwd } from '../flags';
 
 /**
  * options for Reciple client
@@ -91,7 +93,7 @@ export class RecipleClient<Ready extends boolean = boolean> extends Client<Ready
         if (!options.config) throw new Error('Config is not defined.');
         this.config = {...this.config, ...(options.config ?? {})};
 
-        if (this.config.fileLogging.enabled) this.logger.logFile(this.config.fileLogging.logFilePath, false);
+        if (this.config.fileLogging.enabled) this.logger.logFile(this.config.fileLogging.logFilePath ?? path.join(cwd, 'logs/latest.log'), false);
     }
 
     /**
@@ -99,7 +101,7 @@ export class RecipleClient<Ready extends boolean = boolean> extends Client<Ready
      * @param folders List of folders that contains the modules you want to load
      */
     public async startModules(...folders: RestOrArray<string>): Promise<RecipleClient<Ready>> {
-        folders = normalizeArray(folders);
+        folders = normalizeArray(folders).map(f => path.join(cwd, f));
 
         for (const folder of folders) {
             if (this.isClientLogsEnabled()) this.logger.info(`Loading Modules from ${folder}`);

--- a/src/reciple/classes/RecipleClient.ts
+++ b/src/reciple/classes/RecipleClient.ts
@@ -30,12 +30,12 @@ import path from 'path';
 import { cwd } from '../flags';
 
 /**
- * options for Reciple client
+ * Options for Reciple client
  */
 export interface RecipleClientOptions extends ClientOptions { config?: Config; }
 
 /**
- * Reciple client commands object interface
+ * Reciple client commands
  */
 export interface RecipleClientCommands {
     slashCommands: { [commandName: string]: SlashCommandBuilder };
@@ -52,7 +52,7 @@ export interface RecipleClientEvents extends ClientEvents {
 }
 
 /**
- * Create new Reciple client
+ * Reciple client
  */
 export interface RecipleClient<Ready extends boolean = boolean> extends Client<Ready> {
     on<E extends keyof RecipleClientEvents>(event: E, listener: (...args: RecipleClientEvents[E]) => Awaitable<void>): this;

--- a/src/reciple/classes/RecipleConfig.ts
+++ b/src/reciple/classes/RecipleConfig.ts
@@ -45,11 +45,6 @@ export interface Config {
             }
         }
     }
-    ignoredChannels: {
-        enabled: boolean;
-        convertToAllowList: boolean;
-        channels: string[];
-    }
     fileLogging: {
         enabled: boolean;
         debugmode: boolean;

--- a/src/reciple/classes/RecipleConfig.ts
+++ b/src/reciple/classes/RecipleConfig.ts
@@ -57,7 +57,7 @@ export interface Config {
         [messageKey: string]: any;
     }
     ignoredFiles: string[];
-    modulesFolder: string;
+    modulesFolder: string|string[];
     disableVersionCheck: boolean;
     version: string;
 }

--- a/src/reciple/classes/RecipleConfig.ts
+++ b/src/reciple/classes/RecipleConfig.ts
@@ -20,18 +20,6 @@ export interface ConfigCommandPermissions {
 export interface Config {
     token: string;
     commands: {
-        messageCommand: {
-            enabled: boolean;
-            prefix?: string;
-            replyOnError: boolean;
-            allowCommandAlias: boolean;
-            enableCooldown: boolean;
-            commandArgumentSeparator: string;
-            permissions: {
-                enabled: boolean;
-                commands: ConfigCommandPermissions[];
-            }
-        }
         slashCommand: {
             enabled: boolean;
             replyOnError: boolean;
@@ -39,6 +27,18 @@ export interface Config {
             enableCooldown: boolean;
             setRequiredPermissions: boolean;
             guilds?: string[]|string;
+            permissions: {
+                enabled: boolean;
+                commands: ConfigCommandPermissions[];
+            }
+        }
+        messageCommand: {
+            enabled: boolean;
+            prefix?: string;
+            replyOnError: boolean;
+            allowCommandAlias: boolean;
+            enableCooldown: boolean;
+            commandArgumentSeparator: string;
             permissions: {
                 enabled: boolean;
                 commands: ConfigCommandPermissions[];

--- a/src/reciple/classes/RecipleConfig.ts
+++ b/src/reciple/classes/RecipleConfig.ts
@@ -2,7 +2,7 @@ import { ClientOptions, PermissionResolvable } from 'discord.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { isSupportedVersion, version } from '../version';
 import { input, replaceAll } from 'fallout-utility';
-import { token as __token } from '../flags';
+import { cwd, token as __token } from '../flags';
 import path from 'path';
 import yaml from 'yaml';
 
@@ -67,7 +67,7 @@ export interface Config {
  */
 export class RecipleConfig {
     public config: Config = RecipleConfig.getDefaultConfig();
-    public configPath: string = './reciple.yml';
+    public configPath: string = path.join(cwd, 'reciple.yml');
     public static defaultConfigPath = path.join(__dirname, '../../../resource/reciple.yml');
 
     /**
@@ -125,13 +125,8 @@ export class RecipleConfig {
      * @param askIfNull Ask for token if the token is null/undefined
      */
     public parseToken(askIfNull: boolean = true): string|null {
-        let token = __token || null;
-
-        if (!this.config && !token) return token;
-        if (this.config && !this.config?.token && !token) return token || (askIfNull ? this.askToken() : null);
-        
-        token = token || this.config?.token || null;
-        if (!token) return token;
+        let token = __token || this.config?.token || null;
+        if (!token) return token || (askIfNull ? this.askToken() : null);
 
         const envToken = token.toString().split(':');
         if (envToken.length === 2 && envToken[0].toLocaleLowerCase() === 'env' && envToken[1]) {
@@ -152,7 +147,7 @@ export class RecipleConfig {
      * Ask for a token
      */
     private askToken(): string|null {
-        return __token || input({ 'text': 'Bot Token >>> ', echo: '*', repeatIfEmpty: true, exitStrings: ['exit', 'quit', ''], sigint: true }) || null;
+        return __token || input({ text: 'Bot Token >>> ', echo: '*', repeatIfEmpty: true, sigint: true }) || null;
     }
 
     /**

--- a/src/reciple/classes/builders/MessageCommandBuilder.ts
+++ b/src/reciple/classes/builders/MessageCommandBuilder.ts
@@ -29,7 +29,7 @@ export interface MessageCommandValidatedOption {
 }
 
 /**
- * Message command halt data
+ * Halt data for message command
  */
 export type MessageCommandHaltData = CommandHaltData<CommandBuilderType.MessageCommand>;
 

--- a/src/reciple/classes/builders/MessageCommandBuilder.ts
+++ b/src/reciple/classes/builders/MessageCommandBuilder.ts
@@ -1,8 +1,9 @@
-import { CommandBuilderType, CommandExecuteData, CommandExecuteFunction, CommandHaltFunction } from '../../types/builders';
+import { CommandBuilderType, AnyCommandExecuteData, AnyCommandExecuteFunction, AnyCommandHaltFunction } from '../../types/builders';
 import { MessageCommandOptionManager } from '../MessageCommandOptionManager';
 import { MessageCommandOptionBuilder } from './MessageCommandOptionBuilder';
 import { Command as CommandMessage } from 'fallout-utility';
 import { Message, PermissionResolvable } from 'discord.js';
+import { AnyCommandHaltData } from '../../types/commands';
 import { RecipleClient } from '../RecipleClient';
 
 /**
@@ -28,6 +29,21 @@ export interface MessageCommandValidatedOption {
 }
 
 /**
+ * Message command halt data
+ */
+export type MessageCommandHaltData = AnyCommandHaltData<CommandBuilderType.MessageCommand>;
+
+/**
+ * Message command halt function
+ */
+export type MessageCommandHaltFunction = AnyCommandHaltFunction<CommandBuilderType.MessageCommand>;
+
+/**
+ * Message command execute function
+ */
+export type MessageCommandExecuteFunction = AnyCommandExecuteFunction<CommandBuilderType.MessageCommand>;
+
+/**
  * Reciple builder for message command
  */
 export class MessageCommandBuilder {
@@ -42,8 +58,8 @@ export class MessageCommandBuilder {
     public requiredMemberPermissions: PermissionResolvable[] = [];
     public allowExecuteInDM: boolean = true;
     public allowExecuteByBots: boolean = false;
-    public halt?: CommandHaltFunction<this["type"]>;
-    public execute: CommandExecuteFunction<this["type"]> = () => { /* Execute */ };
+    public halt?: MessageCommandHaltFunction;
+    public execute: MessageCommandExecuteFunction = () => { /* Execute */ };
 
     /**
      * Sets the command name
@@ -181,7 +197,7 @@ export class MessageCommandBuilder {
     /**
      * Is a message command execute data
      */
-    public static isMessageCommandExecuteData(executeData: CommandExecuteData): executeData is MessageCommandExecuteData {
+    public static isMessageCommandExecuteData(executeData: AnyCommandExecuteData): executeData is MessageCommandExecuteData {
         return (executeData as MessageCommandExecuteData).builder !== undefined && this.isMessageCommandBuilder((executeData as MessageCommandExecuteData).builder);
     }
 }

--- a/src/reciple/classes/builders/MessageCommandBuilder.ts
+++ b/src/reciple/classes/builders/MessageCommandBuilder.ts
@@ -146,7 +146,7 @@ export class MessageCommandBuilder {
      * Function when the command is interupted 
      * @param halt Function to execute when command is halted
      */
-    public setHalt(halt?: this["type"]): this {
+    public setHalt(halt?: this["halt"]): this {
         this.halt = halt ? halt : undefined;
         return this;
     }

--- a/src/reciple/classes/builders/MessageCommandBuilder.ts
+++ b/src/reciple/classes/builders/MessageCommandBuilder.ts
@@ -188,6 +188,13 @@ export class MessageCommandBuilder {
     }
 
     /**
+     * True if this is a message command builder
+     */
+    public isMessageCommand(): this is MessageCommandBuilder {
+        return this instanceof MessageCommandBuilder;
+    }
+
+    /**
      * Is a message command builder 
      */
     public static isMessageCommandBuilder(builder: any): builder is MessageCommandBuilder {

--- a/src/reciple/classes/builders/MessageCommandBuilder.ts
+++ b/src/reciple/classes/builders/MessageCommandBuilder.ts
@@ -1,4 +1,4 @@
-import { CommandBuilderType, CommandExecuteFunction, CommandHaltFunction } from '../../types/builders';
+import { CommandBuilderType, CommandExecuteData, CommandExecuteFunction, CommandHaltFunction } from '../../types/builders';
 import { MessageCommandOptionManager } from '../MessageCommandOptionManager';
 import { MessageCommandOptionBuilder } from './MessageCommandOptionBuilder';
 import { Command as CommandMessage } from 'fallout-utility';
@@ -31,7 +31,7 @@ export interface MessageCommandValidatedOption {
  * Reciple builder for message command
  */
 export class MessageCommandBuilder {
-    public readonly builder = CommandBuilderType.MessageCommand;
+    public readonly type = CommandBuilderType.MessageCommand;
     public name: string = '';
     public cooldown: number = 0;
     public description: string = '';
@@ -42,8 +42,8 @@ export class MessageCommandBuilder {
     public requiredMemberPermissions: PermissionResolvable[] = [];
     public allowExecuteInDM: boolean = true;
     public allowExecuteByBots: boolean = false;
-    public halt?: CommandHaltFunction<this>;
-    public execute: CommandExecuteFunction<this> = () => { /* Execute */ };
+    public halt?: CommandHaltFunction<this["type"]>;
+    public execute: CommandExecuteFunction<this["type"]> = () => { /* Execute */ };
 
     /**
      * Sets the command name
@@ -130,7 +130,7 @@ export class MessageCommandBuilder {
      * Function when the command is interupted 
      * @param halt Function to execute when command is halted
      */
-    public setHalt(halt?: CommandHaltFunction<this>): this {
+    public setHalt(halt?: this["type"]): this {
         this.halt = halt ? halt : undefined;
         return this;
     }
@@ -139,7 +139,7 @@ export class MessageCommandBuilder {
      * Function when the command is executed 
      * @param execute Function to execute when the command is called 
      */
-    public setExecute(execute: CommandExecuteFunction<this>): this {
+    public setExecute(execute: this["execute"]): this {
         if (!execute || typeof execute !== 'function') throw new TypeError('execute must be a function.');
         this.execute = execute;
         return this;
@@ -169,6 +169,20 @@ export class MessageCommandBuilder {
         if (typeof validateOptions !== 'boolean') throw new TypeError('validateOptions must be a boolean.');
         this.validateOptions = validateOptions;
         return this;
+    }
+
+    /**
+     * Is a message command builder 
+     */
+    public static isMessageCommandBuilder(builder: any): builder is MessageCommandBuilder {
+        return builder instanceof MessageCommandBuilder;
+    }
+
+    /**
+     * Is a message command execute data
+     */
+    public static isMessageCommandExecuteData(executeData: CommandExecuteData): executeData is MessageCommandExecuteData {
+        return (executeData as MessageCommandExecuteData).builder !== undefined && this.isMessageCommandBuilder((executeData as MessageCommandExecuteData).builder);
     }
 }
 

--- a/src/reciple/classes/builders/MessageCommandBuilder.ts
+++ b/src/reciple/classes/builders/MessageCommandBuilder.ts
@@ -1,8 +1,8 @@
 import { CommandBuilderType, AnyCommandExecuteData, CommandHaltFunction, CommandExecuteFunction, SharedCommandBuilderProperties } from '../../types/builders';
+import { Message, normalizeArray, PermissionResolvable, RestOrArray } from 'discord.js';
 import { MessageCommandOptionManager } from '../MessageCommandOptionManager';
 import { MessageCommandOptionBuilder } from './MessageCommandOptionBuilder';
 import { Command as CommandMessage } from 'fallout-utility';
-import { Message, normalizeArray, PermissionResolvable, RestOrArray } from 'discord.js';
 import { CommandHaltData } from '../../types/commands';
 import { RecipleClient } from '../RecipleClient';
 

--- a/src/reciple/classes/builders/MessageCommandBuilder.ts
+++ b/src/reciple/classes/builders/MessageCommandBuilder.ts
@@ -147,12 +147,12 @@ export class MessageCommandBuilder implements SharedCommandBuilderProperties {
         return this;
     }
 
-    public setRequiredBotPermissions(...permissions: RestOrArray<PermissionResolvable>[]): this {
+    public setRequiredBotPermissions(...permissions: RestOrArray<PermissionResolvable>): this {
         this.requiredBotPermissions = normalizeArray(permissions);
         return this;
     }
 
-    public setRequiredMemberPermissions(...permissions: RestOrArray<PermissionResolvable>[]): this {
+    public setRequiredMemberPermissions(...permissions: RestOrArray<PermissionResolvable>): this {
         this.requiredMemberPermissions = normalizeArray(permissions);
         return this;
     }

--- a/src/reciple/classes/builders/MessageCommandBuilder.ts
+++ b/src/reciple/classes/builders/MessageCommandBuilder.ts
@@ -1,20 +1,18 @@
-import { CommandBuilderType, AnyCommandExecuteData, CommandHaltFunction, CommandExecuteFunction, SharedCommandBuilderProperties } from '../../types/builders';
+import { CommandBuilderType, CommandHaltFunction, CommandExecuteFunction, SharedCommandBuilderProperties } from '../../types/builders';
+import { AnyCommandExecuteData, BaseCommandExecuteData, CommandHaltData } from '../../types/commands';
 import { Message, normalizeArray, PermissionResolvable, RestOrArray } from 'discord.js';
 import { MessageCommandOptionManager } from '../MessageCommandOptionManager';
 import { MessageCommandOptionBuilder } from './MessageCommandOptionBuilder';
 import { Command as CommandMessage } from 'fallout-utility';
-import { CommandHaltData } from '../../types/commands';
-import { RecipleClient } from '../RecipleClient';
 
 /**
  * Execute data for message command
  */
-export interface MessageCommandExecuteData {
+export interface MessageCommandExecuteData extends BaseCommandExecuteData {
     message: Message;
     options: MessageCommandOptionManager;
     command: CommandMessage;
     builder: MessageCommandBuilder;
-    client: RecipleClient<true>;
 }
 
 /**

--- a/src/reciple/classes/builders/MessageCommandBuilder.ts
+++ b/src/reciple/classes/builders/MessageCommandBuilder.ts
@@ -1,9 +1,9 @@
-import { CommandBuilderType, AnyCommandExecuteData, AnyCommandExecuteFunction, AnyCommandHaltFunction } from '../../types/builders';
+import { CommandBuilderType, AnyCommandExecuteData, CommandHaltFunction, CommandExecuteFunction } from '../../types/builders';
 import { MessageCommandOptionManager } from '../MessageCommandOptionManager';
 import { MessageCommandOptionBuilder } from './MessageCommandOptionBuilder';
 import { Command as CommandMessage } from 'fallout-utility';
 import { Message, PermissionResolvable } from 'discord.js';
-import { AnyCommandHaltData } from '../../types/commands';
+import { CommandHaltData } from '../../types/commands';
 import { RecipleClient } from '../RecipleClient';
 
 /**
@@ -31,17 +31,17 @@ export interface MessageCommandValidatedOption {
 /**
  * Message command halt data
  */
-export type MessageCommandHaltData = AnyCommandHaltData<CommandBuilderType.MessageCommand>;
+export type MessageCommandHaltData = CommandHaltData<CommandBuilderType.MessageCommand>;
 
 /**
  * Message command halt function
  */
-export type MessageCommandHaltFunction = AnyCommandHaltFunction<CommandBuilderType.MessageCommand>;
+export type MessageCommandHaltFunction = CommandHaltFunction<CommandBuilderType.MessageCommand>;
 
 /**
  * Message command execute function
  */
-export type MessageCommandExecuteFunction = AnyCommandExecuteFunction<CommandBuilderType.MessageCommand>;
+export type MessageCommandExecuteFunction = CommandExecuteFunction<CommandBuilderType.MessageCommand>;
 
 /**
  * Reciple builder for message command
@@ -185,13 +185,6 @@ export class MessageCommandBuilder {
         if (typeof validateOptions !== 'boolean') throw new TypeError('validateOptions must be a boolean.');
         this.validateOptions = validateOptions;
         return this;
-    }
-
-    /**
-     * True if this is a message command builder
-     */
-    public isMessageCommand(): this is MessageCommandBuilder {
-        return this instanceof MessageCommandBuilder;
     }
 
     /**

--- a/src/reciple/classes/builders/SlashCommandBuilder.ts
+++ b/src/reciple/classes/builders/SlashCommandBuilder.ts
@@ -1,10 +1,12 @@
-import { CommandBuilderType, AnyCommandExecuteData, CommandHaltFunction, CommandExecuteFunction } from '../../types/builders';
+import { CommandBuilderType, AnyCommandExecuteData, CommandHaltFunction, CommandExecuteFunction, SharedCommandBuilderProperties } from '../../types/builders';
 import { CommandHaltData } from '../../types/commands';
 import { RecipleClient } from '../RecipleClient';
 
 import {
     ChatInputCommandInteraction,
+    normalizeArray,
     PermissionResolvable,
+    RestOrArray,
     SlashCommandBuilder as DiscordJsSlashCommandBuilder,
     SlashCommandSubcommandBuilder,
     SlashCommandSubcommandGroupBuilder,
@@ -44,7 +46,7 @@ export interface SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
 /**
  * Reciple builder for interaction/slash command
  */
-export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
+export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder implements SharedCommandBuilderProperties {
     public readonly type = CommandBuilderType.SlashCommand;
     public cooldown: number = 0;
     public requiredBotPermissions: PermissionResolvable[] = [];
@@ -53,47 +55,26 @@ export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
     public halt?: SlashCommandHaltFunction;
     public execute: SlashCommandExecuteFunction = () => { /* Execute */ };
 
-    /**
-     * Sets the execute cooldown for this command.
-     * - `0` means no cooldown
-     * @param cooldown Command cooldown in milliseconds
-     */
     public setCooldown(cooldown: number): this {
         this.cooldown = cooldown;
         return this;
     }
 
-    /**
-     * Set required bot permissions to execute the command
-     * @param permissions Bot's required permissions
-     */
-    public setRequiredBotPermissions(...permissions: PermissionResolvable[]): this {
-        this.requiredBotPermissions = permissions;
+    public setRequiredBotPermissions(...permissions: RestOrArray<PermissionResolvable>[]): this {
+        this.requiredBotPermissions = normalizeArray(permissions);
         return this;
     }
 
-    /**
-     * Set required permissions to execute the command
-     * @param permissions User's return permissions
-     */
-    public setRequiredMemberPermissions(...permissions: PermissionResolvable[]): this {
-        this.requiredMemberPermissions = permissions;
+    public setRequiredMemberPermissions(...permissions: RestOrArray<PermissionResolvable>[]): this {
+        this.requiredMemberPermissions = normalizeArray(permissions);
         return this;
     }
 
-    /**
-     * Function when the command is interupted 
-     * @param halt Function to execute when command is halted
-     */
     public setHalt(halt?: this["halt"]): this {
         this.halt = halt ? halt : undefined;
         return this;
     }
 
-    /**
-     * Function when the command is executed 
-     * @param execute Function to execute when the command is called 
-     */
     public setExecute(execute: this["execute"]): this {
         if (!execute || typeof execute !== 'function') throw new Error('execute must be a function.');
         this.execute = execute;

--- a/src/reciple/classes/builders/SlashCommandBuilder.ts
+++ b/src/reciple/classes/builders/SlashCommandBuilder.ts
@@ -1,9 +1,7 @@
-import { CommandBuilderType, CommandExecuteFunction, CommandHaltFunction } from '../../types/builders';
-import { HaltedCommandData } from '../../types/commands';
+import { CommandBuilderType, CommandExecuteData, CommandExecuteFunction, CommandHaltFunction } from '../../types/builders';
 import { RecipleClient } from '../RecipleClient';
 
 import {
-    Awaitable,
     ChatInputCommandInteraction,
     PermissionResolvable,
     SlashCommandBuilder as DiscordJsSlashCommandBuilder,
@@ -33,13 +31,13 @@ export interface SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
  * Reciple builder for interaction/slash command
  */
 export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
-    public readonly builder = CommandBuilderType.SlashCommand;
+    public readonly type = CommandBuilderType.SlashCommand;
     public cooldown: number = 0;
     public requiredBotPermissions: PermissionResolvable[] = [];
     public requiredMemberPermissions: PermissionResolvable[] = [];
     public allowExecuteInDM: boolean = true;
-    public halt?: CommandHaltFunction<this>;
-    public execute: CommandExecuteFunction<this> = () => { /* Execute */ };
+    public halt?: CommandHaltFunction<this["type"]>;
+    public execute: CommandExecuteFunction<this["type"]> = () => { /* Execute */ };
 
     /**
      * Sets the execute cooldown for this command.
@@ -73,7 +71,7 @@ export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
      * Function when the command is interupted 
      * @param halt Function to execute when command is halted
      */
-    public setHalt(halt?: CommandHaltFunction<this>): this {
+    public setHalt(halt?: this["halt"]): this {
         this.halt = halt ? halt : undefined;
         return this;
     }
@@ -82,9 +80,23 @@ export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
      * Function when the command is executed 
      * @param execute Function to execute when the command is called 
      */
-    public setExecute(execute: CommandExecuteFunction<this>): this {
+    public setExecute(execute: this["execute"]): this {
         if (!execute || typeof execute !== 'function') throw new Error('execute must be a function.');
         this.execute = execute;
         return this;
+    }
+
+    /**
+     * Is a slash command builder
+     */
+    public static isSlashCommandBuilder(builder: any): builder is SlashCommandBuilder {
+        return builder instanceof SlashCommandBuilder;
+    }
+
+    /**
+     * Is a slash command execute data 
+     */
+    public static isSlashCommandExecuteData(executeData: CommandExecuteData): executeData is SlashCommandExecuteData {
+        return (executeData as SlashCommandExecuteData).builder !== undefined && this.isSlashCommandBuilder((executeData as SlashCommandExecuteData).builder);
     }
 }

--- a/src/reciple/classes/builders/SlashCommandBuilder.ts
+++ b/src/reciple/classes/builders/SlashCommandBuilder.ts
@@ -1,6 +1,5 @@
-import { CommandBuilderType, AnyCommandExecuteData, CommandHaltFunction, CommandExecuteFunction, SharedCommandBuilderProperties } from '../../types/builders';
-import { CommandHaltData } from '../../types/commands';
-import { RecipleClient } from '../RecipleClient';
+import { CommandBuilderType, CommandHaltFunction, CommandExecuteFunction, SharedCommandBuilderProperties } from '../../types/builders';
+import { AnyCommandExecuteData, BaseCommandExecuteData, CommandHaltData } from '../../types/commands';
 
 import {
     ChatInputCommandInteraction,
@@ -16,10 +15,9 @@ import {
 /**
  * Execute data for slash command
  */
-export interface SlashCommandExecuteData {
+export interface SlashCommandExecuteData extends BaseCommandExecuteData {
     interaction: ChatInputCommandInteraction;
     builder: SlashCommandBuilder;
-    client: RecipleClient<true>;
 }
 
 /**

--- a/src/reciple/classes/builders/SlashCommandBuilder.ts
+++ b/src/reciple/classes/builders/SlashCommandBuilder.ts
@@ -1,5 +1,5 @@
-import { CommandBuilderType, AnyCommandExecuteData, AnyCommandExecuteFunction, AnyCommandHaltFunction } from '../../types/builders';
-import { AnyCommandHaltData } from '../../types/commands';
+import { CommandBuilderType, AnyCommandExecuteData, CommandHaltFunction, CommandExecuteFunction } from '../../types/builders';
+import { CommandHaltData } from '../../types/commands';
 import { RecipleClient } from '../RecipleClient';
 
 import {
@@ -31,17 +31,17 @@ export interface SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
 /**
  * Slash command halt data
  */
-export type SlashCommandHaltData = AnyCommandHaltData<CommandBuilderType.SlashCommand>;
+export type SlashCommandHaltData = CommandHaltData<CommandBuilderType.SlashCommand>;
 
 /**
  * Slash command halt function
  */
-export type SlashCommandHaltFunction = AnyCommandHaltFunction<CommandBuilderType.SlashCommand>;
+export type SlashCommandHaltFunction = CommandHaltFunction<CommandBuilderType.SlashCommand>;
 
 /**
  * Slash command execute function
  */
-export type SlashCommandExecuteFunction = AnyCommandExecuteFunction<CommandBuilderType.SlashCommand>;
+export type SlashCommandExecuteFunction = CommandExecuteFunction<CommandBuilderType.SlashCommand>;
 
 /**
  * Reciple builder for interaction/slash command
@@ -100,13 +100,6 @@ export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
         if (!execute || typeof execute !== 'function') throw new Error('execute must be a function.');
         this.execute = execute;
         return this;
-    }
-    
-    /**
-     * True if this is a slash command builder
-     */
-    public isSlashCommand(): this is SlashCommandBuilder {
-        return this instanceof SlashCommandBuilder;
     }
 
     /**

--- a/src/reciple/classes/builders/SlashCommandBuilder.ts
+++ b/src/reciple/classes/builders/SlashCommandBuilder.ts
@@ -1,4 +1,5 @@
-import { CommandBuilderType, CommandExecuteData, CommandExecuteFunction, CommandHaltFunction } from '../../types/builders';
+import { CommandBuilderType, AnyCommandExecuteData, AnyCommandExecuteFunction, AnyCommandHaltFunction } from '../../types/builders';
+import { AnyCommandHaltData } from '../../types/commands';
 import { RecipleClient } from '../RecipleClient';
 
 import {
@@ -28,6 +29,21 @@ export interface SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
 }
 
 /**
+ * Slash command halt data
+ */
+export type SlashCommandHaltData = AnyCommandHaltData<CommandBuilderType.SlashCommand>;
+
+/**
+ * Slash command halt function
+ */
+export type SlashCommandHaltFunction = AnyCommandHaltFunction<CommandBuilderType.SlashCommand>;
+
+/**
+ * Slash command execute function
+ */
+export type SlashCommandExecuteFunction = AnyCommandExecuteFunction<CommandBuilderType.SlashCommand>;
+
+/**
  * Reciple builder for interaction/slash command
  */
 export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
@@ -36,8 +52,8 @@ export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
     public requiredBotPermissions: PermissionResolvable[] = [];
     public requiredMemberPermissions: PermissionResolvable[] = [];
     public allowExecuteInDM: boolean = true;
-    public halt?: CommandHaltFunction<this["type"]>;
-    public execute: CommandExecuteFunction<this["type"]> = () => { /* Execute */ };
+    public halt?: SlashCommandHaltFunction;
+    public execute: SlashCommandExecuteFunction = () => { /* Execute */ };
 
     /**
      * Sets the execute cooldown for this command.
@@ -96,7 +112,7 @@ export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
     /**
      * Is a slash command execute data 
      */
-    public static isSlashCommandExecuteData(executeData: CommandExecuteData): executeData is SlashCommandExecuteData {
+    public static isSlashCommandExecuteData(executeData: AnyCommandExecuteData): executeData is SlashCommandExecuteData {
         return (executeData as SlashCommandExecuteData).builder !== undefined && this.isSlashCommandBuilder((executeData as SlashCommandExecuteData).builder);
     }
 }

--- a/src/reciple/classes/builders/SlashCommandBuilder.ts
+++ b/src/reciple/classes/builders/SlashCommandBuilder.ts
@@ -20,14 +20,6 @@ export interface SlashCommandExecuteData {
     client: RecipleClient<true>;
 }
 
-export interface SlashCommandSubcommandsOnlyBuilder extends DiscordJsSlashCommandSubcommandsOnlyBuilder,Pick<SlashCommandBuilder, "setCooldown" | "setRequiredBotPermissions" | "setRequiredMemberPermissions" | "setHalt" | "setExecute"> {
-}
-
-export interface SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
-    addSubcommandGroup(input: SlashCommandSubcommandGroupBuilder | ((subcommandGroup: SlashCommandSubcommandGroupBuilder) => SlashCommandSubcommandGroupBuilder)): SlashCommandSubcommandsOnlyBuilder;
-    addSubcommand(input: SlashCommandSubcommandBuilder | ((subcommandGroup: SlashCommandSubcommandBuilder) => SlashCommandSubcommandBuilder)): SlashCommandSubcommandsOnlyBuilder;
-}
-
 /**
  * Slash command halt data
  */
@@ -42,6 +34,12 @@ export type SlashCommandHaltFunction = CommandHaltFunction<CommandBuilderType.Sl
  * Slash command execute function
  */
 export type SlashCommandExecuteFunction = CommandExecuteFunction<CommandBuilderType.SlashCommand>;
+
+export interface SlashCommandSubcommandsOnlyBuilder extends DiscordJsSlashCommandSubcommandsOnlyBuilder,Pick<SlashCommandBuilder, "setCooldown" | "setRequiredBotPermissions" | "setRequiredMemberPermissions" | "setHalt" | "setExecute"> {}
+export interface SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
+    addSubcommandGroup(input: SlashCommandSubcommandGroupBuilder | ((subcommandGroup: SlashCommandSubcommandGroupBuilder) => SlashCommandSubcommandGroupBuilder)): SlashCommandSubcommandsOnlyBuilder;
+    addSubcommand(input: SlashCommandSubcommandBuilder | ((subcommandGroup: SlashCommandSubcommandBuilder) => SlashCommandSubcommandBuilder)): SlashCommandSubcommandsOnlyBuilder;
+}
 
 /**
  * Reciple builder for interaction/slash command
@@ -69,7 +67,7 @@ export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
      * Set required bot permissions to execute the command
      * @param permissions Bot's required permissions
      */
-     public setRequiredBotPermissions(...permissions: PermissionResolvable[]): this {
+    public setRequiredBotPermissions(...permissions: PermissionResolvable[]): this {
         this.requiredBotPermissions = permissions;
         return this;
     }

--- a/src/reciple/classes/builders/SlashCommandBuilder.ts
+++ b/src/reciple/classes/builders/SlashCommandBuilder.ts
@@ -101,6 +101,13 @@ export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
         this.execute = execute;
         return this;
     }
+    
+    /**
+     * True if this is a slash command builder
+     */
+    public isSlashCommand(): this is SlashCommandBuilder {
+        return this instanceof SlashCommandBuilder;
+    }
 
     /**
      * Is a slash command builder

--- a/src/reciple/classes/builders/SlashCommandBuilder.ts
+++ b/src/reciple/classes/builders/SlashCommandBuilder.ts
@@ -14,7 +14,7 @@ import {
 } from 'discord.js';
 
 /**
- * Execute data for interaction command
+ * Execute data for slash command
  */
 export interface SlashCommandExecuteData {
     interaction: ChatInputCommandInteraction;
@@ -44,9 +44,9 @@ export interface SlashCommandBuilder extends DiscordJsSlashCommandBuilder {
 }
 
 /**
- * Reciple builder for interaction/slash command
+ * Reciple builder for slash command
  */
-export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder implements SharedCommandBuilderProperties {
+export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder implements SharedCommandBuilderProperties,SlashCommandBuilder {
     public readonly type = CommandBuilderType.SlashCommand;
     public cooldown: number = 0;
     public requiredBotPermissions: PermissionResolvable[] = [];

--- a/src/reciple/classes/builders/SlashCommandBuilder.ts
+++ b/src/reciple/classes/builders/SlashCommandBuilder.ts
@@ -60,12 +60,12 @@ export class SlashCommandBuilder extends DiscordJsSlashCommandBuilder implements
         return this;
     }
 
-    public setRequiredBotPermissions(...permissions: RestOrArray<PermissionResolvable>[]): this {
+    public setRequiredBotPermissions(...permissions: RestOrArray<PermissionResolvable>): this {
         this.requiredBotPermissions = normalizeArray(permissions);
         return this;
     }
 
-    public setRequiredMemberPermissions(...permissions: RestOrArray<PermissionResolvable>[]): this {
+    public setRequiredMemberPermissions(...permissions: RestOrArray<PermissionResolvable>): this {
         this.requiredMemberPermissions = normalizeArray(permissions);
         return this;
     }

--- a/src/reciple/flags.ts
+++ b/src/reciple/flags.ts
@@ -1,3 +1,4 @@
+import { rawVersion } from './version';
 import { Command } from 'commander';
 
 /**
@@ -6,7 +7,7 @@ import { Command } from 'commander';
 export const flags = new Command()
         .name('reciple')
         .description('Reciple.js - Discord.js handler cli')
-        .version(`v${require('../../package.json').version}`, '-v, --version')
+        .version(`v${rawVersion}`, '-v, --version')
         .option('-t, --token <token>', 'Replace used bot token')
         .option('-c, --config <config>', 'Change path to config file')
         .option('-D, --debugmode', 'Enabled debug mode')

--- a/src/reciple/flags.ts
+++ b/src/reciple/flags.ts
@@ -23,7 +23,7 @@ export const commander = new Command()
 export const flags = commander.opts();
 
 /**
- * Temporary token flag
+ * Token flag
  */
 export const token: string|undefined = flags.token;
 

--- a/src/reciple/flags.ts
+++ b/src/reciple/flags.ts
@@ -1,21 +1,33 @@
 import { rawVersion } from './version';
 import { Command } from 'commander';
+import path from 'path';
 
 /**
- * Used flags
+ * Commander
  */
-export const flags = new Command()
+export const commander = new Command()
         .name('reciple')
         .description('Reciple.js - Discord.js handler cli')
         .version(`v${rawVersion}`, '-v, --version')
+        .argument('[current-working-directory]', 'Change the current working directory')
         .option('-t, --token <token>', 'Replace used bot token')
         .option('-c, --config <config>', 'Change path to config file')
         .option('-D, --debugmode', 'Enabled debug mode')
         .option('-y, --yes', 'Automatically agree to Reciple confirmation prompts')
         .option('-v, --version', 'Display version')
-        .parse().opts();
+        .parse();
+
+/**
+ * Used flags
+ */
+export const flags = commander.opts();
 
 /**
  * Temporary token flag
  */
 export const token: string|undefined = flags.token;
+
+/**
+ * Current working directory
+ */
+export const cwd = path.join(process.cwd(), commander.args[0] || '.');

--- a/src/reciple/flags.ts
+++ b/src/reciple/flags.ts
@@ -12,7 +12,7 @@ export const commander = new Command()
         .argument('[current-working-directory]', 'Change the current working directory')
         .option('-t, --token <token>', 'Replace used bot token')
         .option('-c, --config <config>', 'Change path to config file')
-        .option('-D, --debugmode', 'Enabled debug mode')
+        .option('-D, --debugmode', 'Enable debug mode')
         .option('-y, --yes', 'Automatically agree to Reciple confirmation prompts')
         .option('-v, --version', 'Display version')
         .parse();

--- a/src/reciple/flags.ts
+++ b/src/reciple/flags.ts
@@ -30,4 +30,4 @@ export const token: string|undefined = flags.token;
 /**
  * Current working directory
  */
-export const cwd = path.join(process.cwd(), commander.args[0] || '.');
+export const cwd = commander.args[0] || process.cwd();

--- a/src/reciple/logger.ts
+++ b/src/reciple/logger.ts
@@ -1,6 +1,8 @@
 import { Logger, LogLevels } from 'fallout-utility';
-import { flags } from './flags'
+import { cwd, flags } from './flags'
 import chalk from 'chalk';
+import { createWriteStream } from 'fs';
+import path from 'path';
 
 /**
  * Create new logger

--- a/src/reciple/logger.ts
+++ b/src/reciple/logger.ts
@@ -1,8 +1,6 @@
 import { Logger, LogLevels } from 'fallout-utility';
-import { cwd, flags } from './flags'
+import { flags } from './flags'
 import chalk from 'chalk';
-import { createWriteStream } from 'fs';
-import path from 'path';
 
 /**
  * Create new logger

--- a/src/reciple/modules.ts
+++ b/src/reciple/modules.ts
@@ -1,10 +1,10 @@
 import { AnyCommandBuilder, CommandBuilderType } from './types/builders';
+import { normalizeArray, RestOrArray } from 'discord.js';
 import { RecipleClient } from './classes/RecipleClient';
 import { isSupportedVersion, version } from './version';
 import { existsSync, mkdirSync, readdirSync } from 'fs';
 import wildcard from 'wildcard-match';
 import path from 'path';
-import { normalizeArray, RestOrArray } from 'discord.js';
 
 export type LoadedModules = { commands: AnyCommandBuilder[], modules: RecipleModule[] };
 

--- a/src/reciple/modules.ts
+++ b/src/reciple/modules.ts
@@ -35,9 +35,9 @@ export interface RecipleModule {
  * @param client Reciple client
  * @param folder Modules folder
  */
-export async function loadModules(client: RecipleClient, folder?: string): Promise<LoadedModules> {
+export async function getModules(client: RecipleClient, folder?: string): Promise<LoadedModules> {
     const response: LoadedModules = { commands: [], modules: [] };
-    const modulesDir = client.config.modulesFolder || folder || './modules';
+    const modulesDir = folder || './modules';
     if (!existsSync(modulesDir)) mkdirSync(modulesDir, { recursive: true });
 
     const ignoredFiles = (client.config.ignoredFiles || []).map(file => file.endsWith('.js') ? file : `${file}.js`);

--- a/src/reciple/modules.ts
+++ b/src/reciple/modules.ts
@@ -60,7 +60,7 @@ export async function loadModules(client: RecipleClient, folder?: string): Promi
             if (!await Promise.resolve(module_.onStart(client))) throw new Error(script + ' onStart is not defined or returned false.');
             if (module_.commands) {
                 for (const command of module_.commands) {
-                    if (command.builder === CommandBuilderType.MessageCommand || command.builder === CommandBuilderType.SlashCommand) {
+                    if (command.type === CommandBuilderType.MessageCommand || command.type === CommandBuilderType.SlashCommand) {
                         commands.push(command);
                     }
                 }
@@ -76,12 +76,12 @@ export async function loadModules(client: RecipleClient, folder?: string): Promi
         response.commands.push(
             ...commands.filter((c) => {
                 if (!c.name) {
-                    if (client.isClientLogsEnabled()) client.logger.error(`A ${c.builder} command name is not defined in ${script}`);
+                    if (client.isClientLogsEnabled()) client.logger.error(`A ${CommandBuilderType[c.type]} command name is not defined in ${script}`);
                     return false;
                 }
 
-                if (c.builder === CommandBuilderType.MessageCommand && c.options.length && c.options.some(o => !o.name)) {
-                    if (client.isClientLogsEnabled()) client.logger.error(`A ${c.builder} option name is not defined in ${script}`);
+                if (c.type === CommandBuilderType.MessageCommand && c.options.length && c.options.some(o => !o.name)) {
+                    if (client.isClientLogsEnabled()) client.logger.error(`A ${CommandBuilderType[c.type]} option name is not defined in ${script}`);
                     return false;
                 }
 

--- a/src/reciple/modules.ts
+++ b/src/reciple/modules.ts
@@ -4,8 +4,8 @@ import { RecipleClient } from './classes/RecipleClient';
 import { isSupportedVersion, version } from './version';
 import { existsSync, mkdirSync, readdirSync } from 'fs';
 import wildcard from 'wildcard-match';
-import path from 'path';
 import { cwd } from './flags';
+import path from 'path';
 
 export type LoadedModules = { commands: AnyCommandBuilder[], modules: RecipleModule[] };
 

--- a/src/reciple/modules.ts
+++ b/src/reciple/modules.ts
@@ -4,6 +4,7 @@ import { isSupportedVersion, version } from './version';
 import { existsSync, mkdirSync, readdirSync } from 'fs';
 import wildcard from 'wildcard-match';
 import path from 'path';
+import { normalizeArray, RestOrArray } from 'discord.js';
 
 export type LoadedModules = { commands: AnyCommandBuilder[], modules: RecipleModule[] };
 
@@ -51,13 +52,12 @@ export async function loadModules(client: RecipleClient, folder?: string): Promi
 
         try {
             const reqMod = require(modulePath);
-            module_ = typeof reqMod?.default != 'undefined' ? reqMod.default : reqMod;
+            module_ = reqMod?.default === undefined ? reqMod.default : reqMod;
 
-            if (!module_.versions?.length) throw new Error('Module does not have supported versions.');
-            const versions = typeof module_.versions === 'object' ? module_.versions : [module_.versions];
-
-            if (!client.config.disableVersionCheck && !versions.some(v => isSupportedVersion(v, version))) throw new Error('Module versions is not defined or unsupported; supported versions: ' + module_.versions ?? 'none' + '; current version: '+ version);
-            if (!await Promise.resolve(module_.onStart(client))) throw new Error(script + ' onStart is not defined or returned false.');
+            const versions = normalizeArray([module_.versions] as RestOrArray<string>);
+            if (!module_.versions?.length) throw new Error(`${modulePath} does not have supported versions.`);
+            if (!client.config.disableVersionCheck && !versions.some(v => isSupportedVersion(v, version))) throw new Error(`${modulePath} is unsupported; current version: ${version}; module supported versions: ` + versions.join(', ') ?? 'none');
+            if (!await Promise.resolve(module_.onStart(client)).catch(() => null)) throw new Error(script + ' onStart returned false or undefined.');
             if (module_.commands) {
                 for (const command of module_.commands) {
                     if (command.type === CommandBuilderType.MessageCommand || command.type === CommandBuilderType.SlashCommand) {
@@ -76,12 +76,12 @@ export async function loadModules(client: RecipleClient, folder?: string): Promi
         response.commands.push(
             ...commands.filter((c) => {
                 if (!c.name) {
-                    if (client.isClientLogsEnabled()) client.logger.error(`A ${CommandBuilderType[c.type]} command name is not defined in ${script}`);
+                    if (client.isClientLogsEnabled()) client.logger.error(`A ${CommandBuilderType[c.type]} command name is not defined in ${modulePath}`);
                     return false;
                 }
 
                 if (c.type === CommandBuilderType.MessageCommand && c.options.length && c.options.some(o => !o.name)) {
-                    if (client.isClientLogsEnabled()) client.logger.error(`A ${CommandBuilderType[c.type]} option name is not defined in ${script}`);
+                    if (client.isClientLogsEnabled()) client.logger.error(`A ${CommandBuilderType[c.type]} option name is not defined in ${modulePath}`);
                     return false;
                 }
 
@@ -93,12 +93,12 @@ export async function loadModules(client: RecipleClient, folder?: string): Promi
             script: module_,
             info: {
                 filename: script,
-                versions: typeof module_.versions === 'string' ? [module_.versions] : module_.versions,
+                versions: normalizeArray(module_.versions as RestOrArray<string>),
                 path: modulePath
             }
         });
 
-        if (client.isClientLogsEnabled()) client.logger.info(`Loaded module ${script}`);
+        if (client.isClientLogsEnabled()) client.logger.info(`Loaded module ${modulePath}`);
     }
 
     return response;

--- a/src/reciple/modules.ts
+++ b/src/reciple/modules.ts
@@ -1,18 +1,18 @@
-import { CommandBuilder, CommandBuilderType } from './types/builders';
+import { AnyCommandBuilder, CommandBuilderType } from './types/builders';
 import { RecipleClient } from './classes/RecipleClient';
 import { isSupportedVersion, version } from './version';
 import { existsSync, mkdirSync, readdirSync } from 'fs';
 import wildcard from 'wildcard-match';
 import path from 'path';
 
-export type LoadedModules = { commands: CommandBuilder[], modules: RecipleModule[] };
+export type LoadedModules = { commands: AnyCommandBuilder[], modules: RecipleModule[] };
 
 /**
  * Reciple script object interface
  */
 export interface RecipleScript {
     versions: string | string[];
-    commands?: CommandBuilder[];
+    commands?: AnyCommandBuilder[];
     onLoad?(reciple: RecipleClient): void|Promise<void>;
     onStart(reciple: RecipleClient): boolean|Promise<boolean>;
 }
@@ -46,7 +46,7 @@ export async function loadModules(client: RecipleClient, folder?: string): Promi
 
     for (const script of scripts) {
         const modulePath = path.join(process.cwd(), modulesDir, script);
-        const commands: CommandBuilder[] = [];
+        const commands: AnyCommandBuilder[] = [];
         let module_: RecipleScript;
 
         try {

--- a/src/reciple/modules.ts
+++ b/src/reciple/modules.ts
@@ -5,11 +5,12 @@ import { isSupportedVersion, version } from './version';
 import { existsSync, mkdirSync, readdirSync } from 'fs';
 import wildcard from 'wildcard-match';
 import path from 'path';
+import { cwd } from './flags';
 
 export type LoadedModules = { commands: AnyCommandBuilder[], modules: RecipleModule[] };
 
 /**
- * Reciple script object interface
+ * Reciple script object
  */
 export interface RecipleScript {
     versions: string | string[];
@@ -19,7 +20,7 @@ export interface RecipleScript {
 }
 
 /**
- * Reciple module object interface
+ * Reciple module object
  */
 export interface RecipleModule {
     script: RecipleScript;
@@ -37,7 +38,7 @@ export interface RecipleModule {
  */
 export async function getModules(client: RecipleClient, folder?: string): Promise<LoadedModules> {
     const response: LoadedModules = { commands: [], modules: [] };
-    const modulesDir = folder || 'modules';
+    const modulesDir = folder || path.join(cwd, 'modules');
     if (!existsSync(modulesDir)) mkdirSync(modulesDir, { recursive: true });
 
     const ignoredFiles = (client.config.ignoredFiles || []).map(file => file.endsWith('.js') ? file : `${file}.js`);

--- a/src/reciple/modules.ts
+++ b/src/reciple/modules.ts
@@ -37,7 +37,7 @@ export interface RecipleModule {
  */
 export async function getModules(client: RecipleClient, folder?: string): Promise<LoadedModules> {
     const response: LoadedModules = { commands: [], modules: [] };
-    const modulesDir = folder || './modules';
+    const modulesDir = folder || 'modules';
     if (!existsSync(modulesDir)) mkdirSync(modulesDir, { recursive: true });
 
     const ignoredFiles = (client.config.ignoredFiles || []).map(file => file.endsWith('.js') ? file : `${file}.js`);
@@ -46,7 +46,7 @@ export async function getModules(client: RecipleClient, folder?: string): Promis
     });
 
     for (const script of scripts) {
-        const modulePath = path.join(process.cwd(), modulesDir, script);
+        const modulePath = path.join(modulesDir, script);
         const commands: AnyCommandBuilder[] = [];
         let module_: RecipleScript;
 

--- a/src/reciple/permissions.ts
+++ b/src/reciple/permissions.ts
@@ -28,16 +28,3 @@ export function botHasExecutePermissions(guild?: Guild, requiredPermissions?: Pe
 
     return guild?.members.me ? guild.members.me.permissions.has(requiredPermissions) : false;
 }
-
-/**
- * Check if the channel id is ignored in config file 
- * @param channelId Check if channel id is in ignore list
- * @param ignoredChannelsConfig Ignored channels config
- */
-export function isIgnoredChannel(channelId: string, ignoredChannelsConfig?: Config["ignoredChannels"]): boolean {
-    if (!ignoredChannelsConfig?.enabled) return false;
-    if (ignoredChannelsConfig.channels.includes(channelId) && !ignoredChannelsConfig.convertToAllowList) return true;
-    if (!ignoredChannelsConfig.channels.includes(channelId) && ignoredChannelsConfig.convertToAllowList) return true;
-
-    return false;
-}

--- a/src/reciple/permissions.ts
+++ b/src/reciple/permissions.ts
@@ -1,6 +1,5 @@
 import { UserHasCommandPermissionsOptions } from './types/paramOptions';
 import { Guild, PermissionResolvable } from 'discord.js';
-import { Config } from './classes/RecipleConfig';
 
 /**
  * Check if the user has permissions to execute the given command name

--- a/src/reciple/registerApplicationCommands.ts
+++ b/src/reciple/registerApplicationCommands.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandData, ContextMenuCommandBuilder, SlashCommandBuilder as DiscordJsSlashCommandBuilder } from 'discord.js';
+import { ApplicationCommandData, ContextMenuCommandBuilder, normalizeArray, RestOrArray, SlashCommandBuilder as DiscordJsSlashCommandBuilder } from 'discord.js';
 import { SlashCommandBuilder } from './classes/builders/SlashCommandBuilder';
 import { RegisterApplicationCommandsOptions } from './types/paramOptions';
 
@@ -10,7 +10,7 @@ export type ApplicationCommandBuilder = SlashCommandBuilder|ContextMenuCommandBu
  */
 export async function registerApplicationCommands(options: RegisterApplicationCommandsOptions): Promise<void> {
     const client = options.client;
-    const guilds = typeof options.guilds == 'string' ? [options.guilds] : options.guilds;
+    const guilds = normalizeArray(options.guilds as RestOrArray<string>);
 
     const commands = Object.values(options.commands ?? client.commands.slashCommands).map(cmd => {
         if (typeof (cmd as ApplicationCommandBuilder)?.toJSON == 'undefined') return cmd as ApplicationCommandData;

--- a/src/reciple/registerApplicationCommands.ts
+++ b/src/reciple/registerApplicationCommands.ts
@@ -17,7 +17,7 @@ export async function registerApplicationCommands(options: RegisterApplicationCo
 
         cmd = cmd as ApplicationCommandBuilder;
 
-        if (cmd instanceof SlashCommandBuilder && client.config.commands.slashCommand.setRequiredPermissions) {
+        if (SlashCommandBuilder.isSlashCommandBuilder(cmd) && client.config.commands.slashCommand.setRequiredPermissions) {
             const permissions = client.config.commands.slashCommand.permissions.enabled
                     ? client.config.commands.slashCommand.permissions.commands.find(cmd_ => cmd_.command.toLowerCase() === cmd.name.toLowerCase())?.permissions
                     : undefined;
@@ -28,7 +28,6 @@ export async function registerApplicationCommands(options: RegisterApplicationCo
             }
 
             client.commands.slashCommands[cmd.name] = cmd;
-            return cmd.toJSON();
         }
 
         return cmd.toJSON();

--- a/src/reciple/types/builders.ts
+++ b/src/reciple/types/builders.ts
@@ -1,26 +1,25 @@
+import { MessageCommandBuilder, MessageCommandExecuteData, MessageCommandHaltData } from '../classes/builders/MessageCommandBuilder';
+import { SlashCommandBuilder, SlashCommandExecuteData, SlashCommandHaltData } from '../classes/builders/SlashCommandBuilder';
 import { Awaitable } from 'discord.js';
-import { MessageCommandBuilder, MessageCommandExecuteData } from '../classes/builders/MessageCommandBuilder';
-import { SlashCommandBuilder, SlashCommandExecuteData } from '../classes/builders/SlashCommandBuilder';
-import { CommandHaltData } from './commands';
 
 /**
  * Reciple command builders
  */
-export type CommandBuilder = MessageCommandBuilder|SlashCommandBuilder;
+export type AnyCommandBuilder = MessageCommandBuilder|SlashCommandBuilder;
 /**
  * Reciple command execute data
  */
-export type CommandExecuteData = SlashCommandExecuteData|MessageCommandExecuteData;
+export type AnyCommandExecuteData = SlashCommandExecuteData|MessageCommandExecuteData;
 
 /**
  * Reciple command halt function
  */
-export type CommandHaltFunction<T extends CommandBuilderType> = (haltData: CommandHaltData<T>) => Awaitable<boolean|null|undefined|void>;
+export type AnyCommandHaltFunction<T extends CommandBuilderType> = (haltData: T extends CommandBuilderType.SlashCommand ? SlashCommandHaltData : MessageCommandHaltData) => Awaitable<boolean|null|undefined|void>;
 
 /**
  * Reciple command execute function
  */
-export type CommandExecuteFunction<T extends CommandBuilderType> = (executeData: T extends CommandBuilderType.SlashCommand ? SlashCommandExecuteData : MessageCommandExecuteData) => Awaitable<void>;
+export type AnyCommandExecuteFunction<T extends CommandBuilderType> = (executeData: T extends CommandBuilderType.SlashCommand ? SlashCommandExecuteData : MessageCommandExecuteData) => Awaitable<void>;
 
 /**
  * Types of Reciple command builders

--- a/src/reciple/types/builders.ts
+++ b/src/reciple/types/builders.ts
@@ -1,6 +1,6 @@
-import { MessageCommandBuilder, MessageCommandExecuteData, MessageCommandHaltData, MessageCommandHaltFunction } from '../classes/builders/MessageCommandBuilder';
-import { SlashCommandBuilder, SlashCommandExecuteData, SlashCommandHaltData, SlashCommandHaltFunction } from '../classes/builders/SlashCommandBuilder';
-import { Awaitable } from 'discord.js';
+import { MessageCommandBuilder, MessageCommandExecuteData, MessageCommandExecuteFunction, MessageCommandHaltData, MessageCommandHaltFunction } from '../classes/builders/MessageCommandBuilder';
+import { SlashCommandBuilder, SlashCommandExecuteData, SlashCommandExecuteFunction, SlashCommandHaltData, SlashCommandHaltFunction } from '../classes/builders/SlashCommandBuilder';
+import { Awaitable, PermissionResolvable, RestOrArray } from 'discord.js';
 
 /**
  * Any Reciple command builders
@@ -15,6 +15,11 @@ export type AnyCommandExecuteData = SlashCommandExecuteData|MessageCommandExecut
  * Any Reciple command halt functions
  */
 export type AnyCommandHaltFunction = SlashCommandHaltFunction|MessageCommandHaltFunction;
+
+/**
+ * Any reciple command execute function
+ */
+export type AnyCommandExecuteFunction = SlashCommandExecuteFunction|MessageCommandExecuteFunction;
 
 /**
  * Reciple command halt function
@@ -32,4 +37,49 @@ export type CommandExecuteFunction<T extends CommandBuilderType> = (executeData:
 export enum CommandBuilderType {
     MessageCommand,
     SlashCommand
+}
+
+
+/**
+ * Shared command builder methods
+ */
+export interface SharedCommandBuilderProperties {
+    readonly type: CommandBuilderType;
+    cooldown: number;
+    requiredBotPermissions: PermissionResolvable[];
+    requiredMemberPermissions: PermissionResolvable[];
+    allowExecuteInDM: boolean;
+    halt?: AnyCommandHaltFunction;
+    execute: AnyCommandExecuteFunction;
+
+    /**
+     * Sets the execute cooldown for this command.
+     * - `0` means no cooldown
+     * @param cooldown Command cooldown in milliseconds
+     */
+    setCooldown(cooldown: number): this;
+
+    /**
+     * Set required bot permissions to execute the command
+     * @param permissions Bot's required permissions
+     */
+    setRequiredBotPermissions(...permissions: RestOrArray<PermissionResolvable>): this;
+
+    /**
+     * Set required permissions to execute the command
+     * @param permissions User's return permissions
+     */
+    setRequiredMemberPermissions(...permissions: RestOrArray<PermissionResolvable>): this;
+
+    /**
+     * Function when the command is interupted 
+     * @param halt Function to execute when command is halted
+     */
+    setHalt(halt?: this["halt"]): this;
+
+    /**
+     * Function when the command is executed 
+     * @param execute Function to execute when the command is called 
+     */
+    setExecute(execute: this["execute"]): this;
 }

--- a/src/reciple/types/builders.ts
+++ b/src/reciple/types/builders.ts
@@ -6,10 +6,6 @@ import { Awaitable, PermissionResolvable, RestOrArray } from 'discord.js';
  * Any command builders
  */
 export type AnyCommandBuilder = SlashCommandBuilder|MessageCommandBuilder;
-/**
- * Any command execute data
- */
-export type AnyCommandExecuteData = SlashCommandExecuteData|MessageCommandExecuteData;
 
 /**
  * Any command halt functions

--- a/src/reciple/types/builders.ts
+++ b/src/reciple/types/builders.ts
@@ -3,36 +3,36 @@ import { SlashCommandBuilder, SlashCommandExecuteData, SlashCommandExecuteFuncti
 import { Awaitable, PermissionResolvable, RestOrArray } from 'discord.js';
 
 /**
- * Any Reciple command builders
+ * Any command builders
  */
 export type AnyCommandBuilder = SlashCommandBuilder|MessageCommandBuilder;
 /**
- * Any Reciple command execute data
+ * Any command execute data
  */
 export type AnyCommandExecuteData = SlashCommandExecuteData|MessageCommandExecuteData;
 
 /**
- * Any Reciple command halt functions
+ * Any command halt functions
  */
 export type AnyCommandHaltFunction = SlashCommandHaltFunction|MessageCommandHaltFunction;
 
 /**
- * Any reciple command execute function
+ * Any command execute function
  */
 export type AnyCommandExecuteFunction = SlashCommandExecuteFunction|MessageCommandExecuteFunction;
 
 /**
- * Reciple command halt function
+ * command halt function
  */
 export type CommandHaltFunction<T extends CommandBuilderType> = (haltData: T extends CommandBuilderType.SlashCommand ? SlashCommandHaltData : MessageCommandHaltData) => Awaitable<boolean|null|undefined|void>;
 
 /**
- * Reciple command execute function
+ * command execute function
  */
 export type CommandExecuteFunction<T extends CommandBuilderType> = (executeData: T extends CommandBuilderType.SlashCommand ? SlashCommandExecuteData : MessageCommandExecuteData) => Awaitable<void>;
 
 /**
- * Types of Reciple command builders
+ * Types of command builders
  */
 export enum CommandBuilderType {
     MessageCommand,

--- a/src/reciple/types/builders.ts
+++ b/src/reciple/types/builders.ts
@@ -1,25 +1,30 @@
-import { MessageCommandBuilder, MessageCommandExecuteData, MessageCommandHaltData } from '../classes/builders/MessageCommandBuilder';
-import { SlashCommandBuilder, SlashCommandExecuteData, SlashCommandHaltData } from '../classes/builders/SlashCommandBuilder';
+import { MessageCommandBuilder, MessageCommandExecuteData, MessageCommandHaltData, MessageCommandHaltFunction } from '../classes/builders/MessageCommandBuilder';
+import { SlashCommandBuilder, SlashCommandExecuteData, SlashCommandHaltData, SlashCommandHaltFunction } from '../classes/builders/SlashCommandBuilder';
 import { Awaitable } from 'discord.js';
 
 /**
- * Reciple command builders
+ * Any Reciple command builders
  */
-export type AnyCommandBuilder = MessageCommandBuilder|SlashCommandBuilder;
+export type AnyCommandBuilder = SlashCommandBuilder|MessageCommandBuilder;
 /**
- * Reciple command execute data
+ * Any Reciple command execute data
  */
 export type AnyCommandExecuteData = SlashCommandExecuteData|MessageCommandExecuteData;
 
 /**
+ * Any Reciple command halt functions
+ */
+export type AnyCommandHaltFunction = SlashCommandHaltFunction|MessageCommandHaltFunction;
+
+/**
  * Reciple command halt function
  */
-export type AnyCommandHaltFunction<T extends CommandBuilderType> = (haltData: T extends CommandBuilderType.SlashCommand ? SlashCommandHaltData : MessageCommandHaltData) => Awaitable<boolean|null|undefined|void>;
+export type CommandHaltFunction<T extends CommandBuilderType> = (haltData: T extends CommandBuilderType.SlashCommand ? SlashCommandHaltData : MessageCommandHaltData) => Awaitable<boolean|null|undefined|void>;
 
 /**
  * Reciple command execute function
  */
-export type AnyCommandExecuteFunction<T extends CommandBuilderType> = (executeData: T extends CommandBuilderType.SlashCommand ? SlashCommandExecuteData : MessageCommandExecuteData) => Awaitable<void>;
+export type CommandExecuteFunction<T extends CommandBuilderType> = (executeData: T extends CommandBuilderType.SlashCommand ? SlashCommandExecuteData : MessageCommandExecuteData) => Awaitable<void>;
 
 /**
  * Types of Reciple command builders

--- a/src/reciple/types/builders.ts
+++ b/src/reciple/types/builders.ts
@@ -1,26 +1,26 @@
 import { Awaitable } from 'discord.js';
 import { MessageCommandBuilder, MessageCommandExecuteData } from '../classes/builders/MessageCommandBuilder';
 import { SlashCommandBuilder, SlashCommandExecuteData } from '../classes/builders/SlashCommandBuilder';
-import { HaltedCommandData } from './commands';
+import { CommandHaltData } from './commands';
 
 /**
  * Reciple command builders
  */
 export type CommandBuilder = MessageCommandBuilder|SlashCommandBuilder;
 /**
- * Reciple command builders execute data
+ * Reciple command execute data
  */
-export type CommandBuilderExecuteData = SlashCommandExecuteData|MessageCommandExecuteData;
+export type CommandExecuteData = SlashCommandExecuteData|MessageCommandExecuteData;
 
 /**
  * Reciple command halt function
  */
-export type CommandHaltFunction<Builder extends CommandBuilder> = (haltData: HaltedCommandData<Builder>) => Awaitable<boolean|null|undefined|void>;
+export type CommandHaltFunction<T extends CommandBuilderType> = (haltData: CommandHaltData<T>) => Awaitable<boolean|null|undefined|void>;
 
 /**
  * Reciple command execute function
  */
-export type CommandExecuteFunction<Builder extends CommandBuilder> = (executeData: Builder extends MessageCommandBuilder ? MessageCommandExecuteData : SlashCommandExecuteData) => Awaitable<void>;
+export type CommandExecuteFunction<T extends CommandBuilderType> = (executeData: T extends CommandBuilderType.SlashCommand ? SlashCommandExecuteData : MessageCommandExecuteData) => Awaitable<void>;
 
 /**
  * Types of Reciple command builders

--- a/src/reciple/types/commands.ts
+++ b/src/reciple/types/commands.ts
@@ -1,8 +1,9 @@
 import { MessageCommandExecuteData, MessageCommandHaltData } from '../classes/builders/MessageCommandBuilder';
 import { SlashCommandExecuteData, SlashCommandHaltData } from '../classes/builders/SlashCommandBuilder';
 import { MessageCommandOptionManager } from '../classes/MessageCommandOptionManager';
-import { CommandBuilderType, AnyCommandExecuteData } from '../types/builders';
 import { CooledDownUser } from '../classes/CommandCooldownManager';
+import { RecipleClient } from '../classes/RecipleClient';
+import { CommandBuilderType } from '../types/builders';
 
 /**
  * Any command halt data
@@ -15,9 +16,21 @@ export type AnyCommandHaltData = SlashCommandHaltData|MessageCommandHaltData;
 export type CommandHaltData<T extends CommandBuilderType> = CommandErrorData<T>|CommandCooldownData<T>|(T extends CommandBuilderType.SlashCommand ? never : CommandInvalidArguments<T>|CommandMissingArguments<T>)|CommandMissingMemberPermissions<T>|CommandMissingBotPermissions<T>;
 
 /**
+ * Any command execute data
+ */
+export type AnyCommandExecuteData = SlashCommandExecuteData|MessageCommandExecuteData;
+
+/**
+ * Command execute data
+ */
+export interface BaseCommandExecuteData {
+    client: RecipleClient<true>;
+}
+
+/**
  * Command halt reason base
  */
-export interface CommandHaltReasonBase<T extends CommandBuilderType> {
+export interface BaseCommandHaltData<T extends CommandBuilderType> {
     executeData: T extends CommandBuilderType.SlashCommand
                     ? SlashCommandExecuteData
                     : T extends CommandBuilderType.MessageCommand 
@@ -25,25 +38,25 @@ export interface CommandHaltReasonBase<T extends CommandBuilderType> {
                         : AnyCommandExecuteData
 }
 
-export interface CommandErrorData<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
+export interface CommandErrorData<T extends CommandBuilderType> extends BaseCommandHaltData<T> {
     reason: CommandHaltReason.Error;
     error: any;
 }
-export interface CommandCooldownData<T extends CommandBuilderType> extends CommandHaltReasonBase<T>,CooledDownUser {
+export interface CommandCooldownData<T extends CommandBuilderType> extends BaseCommandHaltData<T>,CooledDownUser {
     reason: CommandHaltReason.Cooldown;
 }
-export interface CommandInvalidArguments<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
+export interface CommandInvalidArguments<T extends CommandBuilderType> extends BaseCommandHaltData<T> {
     reason: CommandHaltReason.InvalidArguments;
     invalidArguments: MessageCommandOptionManager;
 }
-export interface CommandMissingArguments<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
+export interface CommandMissingArguments<T extends CommandBuilderType> extends BaseCommandHaltData<T> {
     reason: CommandHaltReason.MissingArguments;
     missingArguments: MessageCommandOptionManager;
 }
-export interface CommandMissingMemberPermissions<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
+export interface CommandMissingMemberPermissions<T extends CommandBuilderType> extends BaseCommandHaltData<T> {
     reason: CommandHaltReason.MissingMemberPermissions;
 }
-export interface CommandMissingBotPermissions<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
+export interface CommandMissingBotPermissions<T extends CommandBuilderType> extends BaseCommandHaltData<T> {
     reason: CommandHaltReason.MissingBotPermissions;
 }
 

--- a/src/reciple/types/commands.ts
+++ b/src/reciple/types/commands.ts
@@ -1,20 +1,24 @@
 import { MessageCommandExecuteData } from '../classes/builders/MessageCommandBuilder';
-import { SlashCommandExecuteData } from '../classes/builders/SlashCommandBuilder';
 import { MessageCommandOptionManager } from '../classes/MessageCommandOptionManager';
+import { SlashCommandExecuteData } from '../classes/builders/SlashCommandBuilder';
+import { CommandBuilderType, AnyCommandExecuteData } from '../types/builders';
 import { CooledDownUser } from '../classes/CommandCooldownManager';
-import { CommandBuilderType, CommandExecuteData } from '../types/builders';
 
 /**
- * Halted command's data
+ * Any Halted command's data
  */
-export type CommandHaltData<T extends CommandBuilderType = CommandBuilderType> = CommandErrorData<T>|CommandCooldownData<T>|(T extends CommandBuilderType.SlashCommand ? never : CommandInvalidArguments<T>|CommandMissingArguments<T>)|CommandMissingMemberPermissions<T>|CommandMissingBotPermissions<T>;
+export type AnyCommandHaltData<T extends CommandBuilderType = CommandBuilderType> = CommandErrorData<T>|CommandCooldownData<T>|(T extends CommandBuilderType.SlashCommand ? never : CommandInvalidArguments<T>|CommandMissingArguments<T>)|CommandMissingMemberPermissions<T>|CommandMissingBotPermissions<T>;
+
+/**
+ * 
+ */
 
 export interface CommandHaltReasonBase<T extends CommandBuilderType> {
     executeData: T extends CommandBuilderType.SlashCommand
                     ? SlashCommandExecuteData
                     : T extends CommandBuilderType.MessageCommand 
                         ? MessageCommandExecuteData
-                        : CommandExecuteData
+                        : AnyCommandExecuteData
 }
 
 export interface CommandErrorData<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {

--- a/src/reciple/types/commands.ts
+++ b/src/reciple/types/commands.ts
@@ -1,38 +1,45 @@
 import { MessageCommandExecuteData } from '../classes/builders/MessageCommandBuilder';
-import { SlashCommandBuilder, SlashCommandExecuteData } from '../classes/builders/SlashCommandBuilder';
+import { SlashCommandExecuteData } from '../classes/builders/SlashCommandBuilder';
 import { MessageCommandOptionManager } from '../classes/MessageCommandOptionManager';
 import { CooledDownUser } from '../classes/CommandCooldownManager';
-import { CommandBuilder } from '../types/builders';
+import { CommandBuilderType, CommandExecuteData } from '../types/builders';
 
 /**
  * Halted command's data
  */
-export type HaltedCommandData<Builder extends CommandBuilder = CommandBuilder> = CommandErrorData<Builder>|CommandCooldownData<Builder>|(Builder extends SlashCommandBuilder ? never : CommandInvalidArguments<Builder>|CommandMissingArguments<Builder>)|CommandMissingMemberPermissions<Builder>|CommandMissingBotPermissions<Builder>;
+export type CommandHaltData<T extends CommandBuilderType = CommandBuilderType> = CommandErrorData<T>|CommandCooldownData<T>|(T extends CommandBuilderType.SlashCommand ? never : CommandInvalidArguments<T>|CommandMissingArguments<T>)|CommandMissingMemberPermissions<T>|CommandMissingBotPermissions<T>;
 
-export interface CommandHaltBaseData<Builder extends CommandBuilder> { executeData: Builder extends SlashCommandBuilder ? SlashCommandExecuteData : MessageCommandExecuteData }
-export interface CommandErrorData<Builder extends CommandBuilder> extends CommandHaltBaseData<Builder> {
-    reason: HaltedCommandReason.Error; error: any;
+export interface CommandHaltBaseData<T extends CommandBuilderType> {
+    executeData: T extends CommandBuilderType.SlashCommand
+                    ? SlashCommandExecuteData
+                    : T extends CommandBuilderType.MessageCommand 
+                        ? MessageCommandExecuteData
+                        : CommandExecuteData
 }
-export interface CommandCooldownData<Builder extends CommandBuilder> extends CommandHaltBaseData<Builder>,CooledDownUser {
-    reason: HaltedCommandReason.Cooldown;
+
+export interface CommandErrorData<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+    reason: CommandHaltReason.Error; error: any;
 }
-export interface CommandInvalidArguments<Builder extends CommandBuilder> extends CommandHaltBaseData<Builder> {
-    reason: HaltedCommandReason.InvalidArguments; invalidArguments: MessageCommandOptionManager;
+export interface CommandCooldownData<T extends CommandBuilderType> extends CommandHaltBaseData<T>,CooledDownUser {
+    reason: CommandHaltReason.Cooldown;
 }
-export interface CommandMissingArguments<Builder extends CommandBuilder> extends CommandHaltBaseData<Builder> {
-    reason: HaltedCommandReason.MissingArguments; missingArguments: MessageCommandOptionManager;
+export interface CommandInvalidArguments<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+    reason: CommandHaltReason.InvalidArguments; invalidArguments: MessageCommandOptionManager;
 }
-export interface CommandMissingMemberPermissions<Builder extends CommandBuilder> extends CommandHaltBaseData<Builder> {
-    reason: HaltedCommandReason.MissingMemberPermissions;
+export interface CommandMissingArguments<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+    reason: CommandHaltReason.MissingArguments; missingArguments: MessageCommandOptionManager;
 }
-export interface CommandMissingBotPermissions<Builder extends CommandBuilder> extends CommandHaltBaseData<Builder> {
-    reason: HaltedCommandReason.MissingBotPermissions;
+export interface CommandMissingMemberPermissions<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+    reason: CommandHaltReason.MissingMemberPermissions;
+}
+export interface CommandMissingBotPermissions<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+    reason: CommandHaltReason.MissingBotPermissions;
 }
 
 /**
  * Command halt reasons
  */
-export enum HaltedCommandReason {
+export enum CommandHaltReason {
     Error,
     Cooldown,
     InvalidArguments,

--- a/src/reciple/types/commands.ts
+++ b/src/reciple/types/commands.ts
@@ -10,9 +10,8 @@ import { CooledDownUser } from '../classes/CommandCooldownManager';
 export type AnyCommandHaltData<T extends CommandBuilderType = CommandBuilderType> = CommandErrorData<T>|CommandCooldownData<T>|(T extends CommandBuilderType.SlashCommand ? never : CommandInvalidArguments<T>|CommandMissingArguments<T>)|CommandMissingMemberPermissions<T>|CommandMissingBotPermissions<T>;
 
 /**
- * 
+ * Command halt reason base interface
  */
-
 export interface CommandHaltReasonBase<T extends CommandBuilderType> {
     executeData: T extends CommandBuilderType.SlashCommand
                     ? SlashCommandExecuteData
@@ -22,16 +21,19 @@ export interface CommandHaltReasonBase<T extends CommandBuilderType> {
 }
 
 export interface CommandErrorData<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
-    reason: CommandHaltReason.Error; error: any;
+    reason: CommandHaltReason.Error;
+    error: any;
 }
 export interface CommandCooldownData<T extends CommandBuilderType> extends CommandHaltReasonBase<T>,CooledDownUser {
     reason: CommandHaltReason.Cooldown;
 }
 export interface CommandInvalidArguments<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
-    reason: CommandHaltReason.InvalidArguments; invalidArguments: MessageCommandOptionManager;
+    reason: CommandHaltReason.InvalidArguments;
+    invalidArguments: MessageCommandOptionManager;
 }
 export interface CommandMissingArguments<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
-    reason: CommandHaltReason.MissingArguments; missingArguments: MessageCommandOptionManager;
+    reason: CommandHaltReason.MissingArguments;
+    missingArguments: MessageCommandOptionManager;
 }
 export interface CommandMissingMemberPermissions<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
     reason: CommandHaltReason.MissingMemberPermissions;

--- a/src/reciple/types/commands.ts
+++ b/src/reciple/types/commands.ts
@@ -1,13 +1,18 @@
-import { MessageCommandExecuteData } from '../classes/builders/MessageCommandBuilder';
+import { MessageCommandExecuteData, MessageCommandHaltData } from '../classes/builders/MessageCommandBuilder';
+import { SlashCommandExecuteData, SlashCommandHaltData } from '../classes/builders/SlashCommandBuilder';
 import { MessageCommandOptionManager } from '../classes/MessageCommandOptionManager';
-import { SlashCommandExecuteData } from '../classes/builders/SlashCommandBuilder';
 import { CommandBuilderType, AnyCommandExecuteData } from '../types/builders';
 import { CooledDownUser } from '../classes/CommandCooldownManager';
 
 /**
- * Any Halted command's data
+ * Any reciple halted command data
  */
-export type AnyCommandHaltData<T extends CommandBuilderType = CommandBuilderType> = CommandErrorData<T>|CommandCooldownData<T>|(T extends CommandBuilderType.SlashCommand ? never : CommandInvalidArguments<T>|CommandMissingArguments<T>)|CommandMissingMemberPermissions<T>|CommandMissingBotPermissions<T>;
+export type AnyCommandHaltData = SlashCommandHaltData|MessageCommandHaltData;
+
+/**
+ * Halted command data
+ */
+export type CommandHaltData<T extends CommandBuilderType> = CommandErrorData<T>|CommandCooldownData<T>|(T extends CommandBuilderType.SlashCommand ? never : CommandInvalidArguments<T>|CommandMissingArguments<T>)|CommandMissingMemberPermissions<T>|CommandMissingBotPermissions<T>;
 
 /**
  * Command halt reason base interface

--- a/src/reciple/types/commands.ts
+++ b/src/reciple/types/commands.ts
@@ -5,17 +5,17 @@ import { CommandBuilderType, AnyCommandExecuteData } from '../types/builders';
 import { CooledDownUser } from '../classes/CommandCooldownManager';
 
 /**
- * Any reciple halted command data
+ * Any command halt data
  */
 export type AnyCommandHaltData = SlashCommandHaltData|MessageCommandHaltData;
 
 /**
- * Halted command data
+ * command halt data
  */
 export type CommandHaltData<T extends CommandBuilderType> = CommandErrorData<T>|CommandCooldownData<T>|(T extends CommandBuilderType.SlashCommand ? never : CommandInvalidArguments<T>|CommandMissingArguments<T>)|CommandMissingMemberPermissions<T>|CommandMissingBotPermissions<T>;
 
 /**
- * Command halt reason base interface
+ * Command halt reason base
  */
 export interface CommandHaltReasonBase<T extends CommandBuilderType> {
     executeData: T extends CommandBuilderType.SlashCommand

--- a/src/reciple/types/commands.ts
+++ b/src/reciple/types/commands.ts
@@ -9,7 +9,7 @@ import { CommandBuilderType, CommandExecuteData } from '../types/builders';
  */
 export type CommandHaltData<T extends CommandBuilderType = CommandBuilderType> = CommandErrorData<T>|CommandCooldownData<T>|(T extends CommandBuilderType.SlashCommand ? never : CommandInvalidArguments<T>|CommandMissingArguments<T>)|CommandMissingMemberPermissions<T>|CommandMissingBotPermissions<T>;
 
-export interface CommandHaltBaseData<T extends CommandBuilderType> {
+export interface CommandHaltReasonBase<T extends CommandBuilderType> {
     executeData: T extends CommandBuilderType.SlashCommand
                     ? SlashCommandExecuteData
                     : T extends CommandBuilderType.MessageCommand 
@@ -17,22 +17,22 @@ export interface CommandHaltBaseData<T extends CommandBuilderType> {
                         : CommandExecuteData
 }
 
-export interface CommandErrorData<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+export interface CommandErrorData<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
     reason: CommandHaltReason.Error; error: any;
 }
-export interface CommandCooldownData<T extends CommandBuilderType> extends CommandHaltBaseData<T>,CooledDownUser {
+export interface CommandCooldownData<T extends CommandBuilderType> extends CommandHaltReasonBase<T>,CooledDownUser {
     reason: CommandHaltReason.Cooldown;
 }
-export interface CommandInvalidArguments<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+export interface CommandInvalidArguments<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
     reason: CommandHaltReason.InvalidArguments; invalidArguments: MessageCommandOptionManager;
 }
-export interface CommandMissingArguments<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+export interface CommandMissingArguments<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
     reason: CommandHaltReason.MissingArguments; missingArguments: MessageCommandOptionManager;
 }
-export interface CommandMissingMemberPermissions<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+export interface CommandMissingMemberPermissions<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
     reason: CommandHaltReason.MissingMemberPermissions;
 }
-export interface CommandMissingBotPermissions<T extends CommandBuilderType> extends CommandHaltBaseData<T> {
+export interface CommandMissingBotPermissions<T extends CommandBuilderType> extends CommandHaltReasonBase<T> {
     reason: CommandHaltReason.MissingBotPermissions;
 }
 

--- a/src/reciple/types/paramOptions.ts
+++ b/src/reciple/types/paramOptions.ts
@@ -3,7 +3,7 @@ import { ApplicationCommandData, PermissionsBitField } from 'discord.js';
 import { RecipleModule, RecipleScript } from '../modules';
 import { RecipleClient } from '../classes/RecipleClient';
 import { Config } from '../classes/RecipleConfig';
-import { CommandBuilder } from './builders';
+import { AnyCommandBuilder } from './builders';
 
 export interface RecipleClientAddModuleOptions {
     /**
@@ -36,7 +36,7 @@ export interface RegisterApplicationCommandsOptions {
 }
 
 export interface UserHasCommandPermissionsOptions {
-    builder: CommandBuilder;
+    builder: AnyCommandBuilder;
     memberPermissions?: PermissionsBitField;
     commandPermissions?: Config["commands"]["slashCommand"]["permissions"]|Config["commands"]["messageCommand"]["permissions"];
 }

--- a/src/reciple/types/paramOptions.ts
+++ b/src/reciple/types/paramOptions.ts
@@ -7,7 +7,7 @@ import { AnyCommandBuilder } from './builders';
 
 export interface RecipleClientAddModuleOptions {
     /**
-     * The Module script
+     * The module script
      */
     script: RecipleScript;
     /**


### PR DESCRIPTION
# Changes
- Rename `CommandBuilder#builder` -> `CommandBuilder#type`
- Added Static methods for message command builder `isMessageCommandBuilder()` && `isMessageCommandExecuteData()`
- Added Static methods for message slash builder `isSlashCommandBuilder()` && `isSlashCommandExecuteData()`
- Rename `HaltedCommandData` -> `AnyCommandHaltData`
- Rename `HaltedCommandReason` -> `CommandHaltReason`
- Rename `CommandBuilderExecuteData` -> `AnyCommandExecuteData`
- Added types `MessageCommandHaltData` `SlashCommandHaltData`
- Added types `MessageCommandHaltFunction` `SlashCommandHaltFunction`
- Added types `MessageCommandExecuteFunction` `SlashCommandExecuteFunction`
- Removed Ignored channels
- Rename `RecipleClient#commandCooldowns` -> `RecipleClient#cooldowns`
- Clean cooldowns every discord.js cache sweep
- Merged events `recipleMessageCommandCreate` & `recipleInteractionCommandCreate` to `recipleCommandExecute`
- Rename `additionalInteractionCommands` -> `additionalApplicationCommands`
- Prioritize slash command over message commands
- Rename `loadModules()` -> `getModules()`
- Allow loading modules from multiple folders
- Allow changing cwd via commands arg
- New interface `BaseCommandExecuteData`
- Rename `CommandHaltBaseData` -> `BaseCommandHaltData`